### PR TITLE
fix: resolve container module path issue by copying source code directly [AI]

### DIFF
--- a/.github/workflows/container-build-pr.yml
+++ b/.github/workflows/container-build-pr.yml
@@ -14,24 +14,6 @@ jobs:
       - name: Set version
         run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
-        with:
-          # Install a specific version of uv.
-          version: "0.7.21"
-          enable-cache: true
-          cache-dependency-glob: "uv.lock"
-
-      - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        with:
-          python-version-file: "pyproject.toml"
-
-      - name: Build wheel
-        run: |
-          uv build --wheel
-          echo "WHEEL_FILE=$(ls dist/*.whl | xargs basename)" >> $GITHUB_ENV
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
 

--- a/.github/workflows/container-build-push.yml
+++ b/.github/workflows/container-build-push.yml
@@ -19,24 +19,6 @@ jobs:
       - name: Set version
         run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
-        with:
-          # Install a specific version of uv.
-          version: "0.7.21"
-          enable-cache: true
-          cache-dependency-glob: "uv.lock"
-
-      - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        with:
-          python-version-file: "pyproject.toml"
-
-      - name: Build wheel
-        run: |
-          uv build --wheel
-          echo "WHEEL_FILE=$(ls dist/*.whl | xargs basename)" >> $GITHUB_ENV
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
 

--- a/Containerfile
+++ b/Containerfile
@@ -15,10 +15,10 @@ WORKDIR /app
 # Copy dependency files
 COPY pyproject.toml uv.lock README.md ./
 
-# Install dependencies only
+# Install dependencies only (excluding the current package)
 RUN --mount=type=cache,target=/root/.cache \
     uv venv && \
-    uv sync --frozen --no-dev
+    uv sync --frozen --no-dev --no-install-project
 
 # Runtime stage: Python 3.12.8-slim-bookworm
 FROM docker.io/library/python:3.12.8-slim-bookworm@sha256:10f3aaab98db50cba827d3b33a91f39dc9ec2d02ca9b85cbc5008220d07b17f3

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-# Build stage: Python 3.12.8-bookworm
+# Build stage: Python 3.12.8-bookworm  
 FROM docker.io/library/python:3.12.8-bookworm@sha256:68ca65265c466f4b64f8ddab669e13bcba8d4ba77ec4c26658d36f2b9d1b1cad as build-python
 
 ENV UV_LINK_MODE=copy \
@@ -6,21 +6,21 @@ ENV UV_LINK_MODE=copy \
     UV_PYTHON_DOWNLOADS=never \
     PYTHONUNBUFFERED=1
 
-# Install uv.
+# Install uv
 COPY --from=ghcr.io/astral-sh/uv:0.5.21@sha256:a8d9b557b6cd6ede1842b0e03cd7ac26870e2c6b4eea4e10dab67cbd3145f8d9 /uv /uvx /bin/
 
 # Set working directory
 WORKDIR /app
-COPY assets /app/assets
 
-# Copy dependencies and pre-built wheel
-COPY dist/*.whl /app/dist/
+# Copy dependency files
+COPY pyproject.toml uv.lock README.md ./
 
+# Install dependencies only
 RUN --mount=type=cache,target=/root/.cache \
     uv venv && \
-    uv pip install dist/*.whl
+    uv sync --frozen --no-dev
 
-# runtime stage: Python 3.12.8-slim-bookworm
+# Runtime stage: Python 3.12.8-slim-bookworm
 FROM docker.io/library/python:3.12.8-slim-bookworm@sha256:10f3aaab98db50cba827d3b33a91f39dc9ec2d02ca9b85cbc5008220d07b17f3
 
 ENV PYTHONUNBUFFERED=1
@@ -29,7 +29,13 @@ ENV PYTHONUNBUFFERED=1
 RUN addgroup --system --gid 1001 appuser && adduser --system --uid 1001 --no-create-home --ingroup appuser appuser
 
 WORKDIR /app
-COPY --from=build-python /app /app
+
+# Copy virtual environment from build stage
+COPY --from=build-python /app/.venv /app/.venv
+
+# Copy application source code and assets
+COPY app/ /app/app/
+COPY assets/ /app/assets/
 
 ENV PATH="/app/.venv/bin:$PATH"
 
@@ -40,4 +46,4 @@ USER appuser
 EXPOSE 8080
 
 # Start the application as the non-root user
-CMD ["fastapi", "run", "app.main", "--proxy-headers", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["fastapi", "run", "app/main.py:app", "--proxy-headers", "--host", "0.0.0.0", "--port", "8080"]


### PR DESCRIPTION
- Update Containerfile to copy app source code instead of building wheels
- Include README.md for package installation requirements
- Remove wheel building steps from GitHub workflows
- Use FastAPI CLI with direct file path: app/main.py:app
- Eliminates module path resolution issues in containers
- Removes need for git/hatch-vcs in container builds
- Improves build performance with better layer caching

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>